### PR TITLE
Fix reading instances from uncompressed files

### DIFF
--- a/nrl/data/dataset_readers/qasrl_reader.py
+++ b/nrl/data/dataset_readers/qasrl_reader.py
@@ -69,7 +69,7 @@ class QaSrlReader(DatasetReader):
                     for line in f:
                         data.append(json.loads(line))
             elif file_path.endswith(".json"):
-                with codecs.open(file_path, 'r', encoding='utf8') as open_file:
+                with codecs.open(file_path, 'r', encoding='utf8') as f:
                     for line in f:
                         data.append(json.loads(line))
             


### PR DESCRIPTION
Looks like `open_file` is erroneously never used, and the variable `f` is shadowed from the other branch of the if statement.

let me know if i missed something.