### PR TITLE
Fix reading non-gzipped files and point predictor to online GloVe

### DIFF
--- a/nrl/data/dataset_readers/qasrl_reader.py
+++ b/nrl/data/dataset_readers/qasrl_reader.py
@@ -60,19 +60,18 @@ class QaSrlReader(DatasetReader):
         for file_path in file_list.split(","):
             if file_path.strip() == "":
                 continue
-            file_path = cached_path(file_path)
 
             logger.info("Reading QASRL instances from dataset file at: %s", file_path)
             data = []
             if file_path.endswith('.gz'):
-                with gzip.open(file_path, 'r') as f:
+                with gzip.open(cached_path(file_path), 'r') as f:
                     for line in f:
                         data.append(json.loads(line))
-            elif file_path.endswith(".json"):
-                with codecs.open(file_path, 'r', encoding='utf8') as f:
+            elif file_path.endswith(".jsonl"):
+                with codecs.open(cached_path(file_path), 'r', encoding='utf8') as f:
                     for line in f:
                         data.append(json.loads(line))
-            
+ 
             for item in data:
                 sent_id = item["sentenceId"]
                 sentence_tokens = item["sentenceTokens"]

--- a/nrl/service/predictors/qasrl_parser.py
+++ b/nrl/service/predictors/qasrl_parser.py
@@ -69,7 +69,7 @@ class QaSrlParserPredictor(Predictor):
 
         self._verb_map = read_verb_file("data/wiktionary/en_verb_inflections.txt")
 
-        self._pretrained_vectors = read_pretrained_file("data/glove/glove.6B.100d.txt.gz")
+        self._pretrained_vectors = read_pretrained_file("https://s3-us-west-2.amazonaws.com/allennlp/datasets/glove/glove.6B.100d.txt.gz")
 
     def _sentence_to_qasrl_instances(self, json_dict: JsonDict) -> Tuple[List[Instance], JsonDict]:
         sentence = json_dict["sentence"]


### PR DESCRIPTION
* Use `.jsonl` suffix for uncompressed files
* Check extension of the non-cached path instead of the cached path (this issue was causing it to break for me)
* Point the predictor to AllenNLP's GloVe vector URL instead of requiring a local download